### PR TITLE
Import Formatter and Error from std::fmt as opposed to private serde types

### DIFF
--- a/src/model/qstring.rs
+++ b/src/model/qstring.rs
@@ -3,11 +3,9 @@ Provides a namespace-qualified string.
 */
 
 use regex::Regex;
-use serde::export::fmt::Error;
-use serde::export::Formatter;
 use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt;
 use std::fmt::Display;
+use std::fmt::{self, Error, Formatter};
 use std::str::FromStr;
 use std::string::ToString;
 


### PR DESCRIPTION
Fixes the following errors when running a `cargo test` on the repo:

```
error[E0603]: module `export` is private
   --> src\model\qstring.rs:6:12
    |
6   | use serde::export::fmt::Error;
    |            ^^^^^^ private module
    |
note: the module `export` is defined here
   --> C:\Users\macks\.cargo\registry\src\github.com-1ecc6299db9ec823\serde-1.0.137\src\lib.rs:274:5
    |
274 | use self::__private as export;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0603]: module `export` is private
   --> src\model\qstring.rs:7:12
    |
7   | use serde::export::Formatter;
    |            ^^^^^^ private module
    |
note: the module `export` is defined here
   --> C:\Users\macks\.cargo\registry\src\github.com-1ecc6299db9ec823\serde-1.0.137\src\lib.rs:274:5
    |
274 | use self::__private as export;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
```