### PR TITLE
Import Formatter and Error from std::fmt as opposed to private serde types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ offline_eval = ["tracing"]
 service_config = ["toml"]
 
 [dependencies]
-uuid = { version = "0.8.1", features = ["serde", "v4"] }
+uuid = { version = "1.1.2", features = ["serde", "v4"] }
 lazy_static = "1.4.0"
 regex = "1.3.7"
 serde = { version = "1.0.110", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ serde_json = "1.0.53"
 # Command-Line feature dependencies
 structopt = { optional = true, version = "0.3.14" }
 tracing = { optional = true, version = "0.1.14" }
-tracing-subscriber = { optional = true, version = "0.3.4" }
+tracing-subscriber = { optional = true, version = "0.3.11", features = ["env-filter"] }
 
 # Service Config feature dependencies
 toml = { optional = true, version = "0.5.6" }

--- a/src/document/latex.rs
+++ b/src/document/latex.rs
@@ -79,7 +79,7 @@ impl PolicyVisitor for LatexGenerator {
         writeln!(self.writer.as_mut(), "\\section{{Policy}}").expect(IO_ERROR_MSG);
     }
 
-    fn id(&mut self, i: &String) {
+    fn id(&mut self, i: &str) {
         self.newln();
         writeln!(
             self.writer.as_mut(),
@@ -166,7 +166,7 @@ impl StatementVisitor for LatexGenerator {
         self.newln();
     }
 
-    fn sid(&mut self, s: &String) {
+    fn sid(&mut self, s: &str) {
         write!(
             self.writer.as_mut(),
             "The statement \\textit{{identifier}} is \\texttt{{\\small{{{}}}}}. ",
@@ -329,7 +329,7 @@ impl ConditionVisitor for LatexGenerator {
                 OneOrAll::All(vs) => format!(
                     "\\{{{}\\}}",
                     vs.iter()
-                        .map(|v| condition_value(v))
+                        .map(condition_value)
                         .collect::<Vec<String>>()
                         .join(", ")
                 ),
@@ -344,7 +344,7 @@ impl ConditionVisitor for LatexGenerator {
 // ------------------------------------------------------------------------------------------------
 
 fn string_value(v: &str) -> String {
-    format!("``{}''", v.to_string())
+    format!("``{}''", v)
         .replace('$', r"\$")
         .replace('{', r"\{")
         .replace('}', r"\}")

--- a/src/document/markdown.rs
+++ b/src/document/markdown.rs
@@ -53,7 +53,7 @@ impl PolicyVisitor for MarkdownGenerator {
         writeln!(self.writer.as_mut(), "# Policy").expect(IO_ERROR_MSG);
     }
 
-    fn id(&mut self, i: &String) {
+    fn id(&mut self, i: &str) {
         self.newln();
         writeln!(self.writer.as_mut(), "> Policy ID: {}", i).expect(IO_ERROR_MSG);
     }
@@ -82,7 +82,7 @@ impl StatementVisitor for MarkdownGenerator {
         writeln!(self.writer.as_mut(), "## Statement").expect(IO_ERROR_MSG);
     }
 
-    fn sid(&mut self, s: &String) {
+    fn sid(&mut self, s: &str) {
         self.newln();
         writeln!(self.writer.as_mut(), "> Statement ID: {}", s).expect(IO_ERROR_MSG);
     }
@@ -193,9 +193,9 @@ impl ConditionVisitor for MarkdownGenerator {
             } else {
                 ""
             },
-            f.to_string(),
+            f,
             if op.if_exists {
-                format!(" `**`THEN`**\n   * *`{}`*`", f.to_string())
+                format!(" `**`THEN`**\n   * *`{}`*`", f)
             } else {
                 "".to_string()
             },
@@ -232,7 +232,7 @@ impl ConditionVisitor for MarkdownGenerator {
                 OneOrAll::All(vs) => format!(
                     "{:?}",
                     vs.iter()
-                        .map(|v| condition_value(v))
+                        .map(condition_value)
                         .collect::<Vec<String>>()
                 ),
             }

--- a/src/document/visitor.rs
+++ b/src/document/visitor.rs
@@ -27,7 +27,7 @@ pub trait PolicyVisitor {
     fn start(&mut self) {}
 
     /// Called by the walker to allow handling of the `id` component of the Policy.
-    fn id(&mut self, i: &String) {}
+    fn id(&mut self, i: &str) {}
 
     /// Called by the walker to allow handling of the `version` component of the Policy.
     fn version(&mut self, v: &Version) {}
@@ -61,7 +61,7 @@ pub trait StatementVisitor {
     fn start(&mut self) {}
 
     /// Called by the walker to allow handling of the `sid` component of the Statement.
-    fn sid(&mut self, s: &String) {}
+    fn sid(&mut self, s: &str) {}
 
     /// Called by the walker to allow handling of the `effect` component of the Statement.
     fn effect(&mut self, e: &Effect) {}

--- a/src/model/builder.rs
+++ b/src/model/builder.rs
@@ -42,7 +42,7 @@ use std::collections::HashMap;
 ///
 /// The top-level `Policy` builder.
 ///
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct PolicyBuilder {
     version: Option<Version>,
     id: Option<String>,
@@ -76,16 +76,6 @@ pub struct ConditionBuilder {
 // ------------------------------------------------------------------------------------------------
 // Implementations
 // ------------------------------------------------------------------------------------------------
-
-impl Default for PolicyBuilder {
-    fn default() -> Self {
-        PolicyBuilder {
-            version: None,
-            id: None,
-            statements: Vec::new(),
-        }
-    }
-}
 
 impl PolicyBuilder {
     /// Create a new, empty, policy builder
@@ -124,7 +114,7 @@ impl PolicyBuilder {
     }
 
     /// Add a list of statements to this policy.
-    pub fn evaluate_statements(&mut self, statements: &mut Vec<StatementBuilder>) -> &mut Self {
+    pub fn evaluate_statements(&mut self, statements: &mut [StatementBuilder]) -> &mut Self {
         self.statements.extend(
             statements
                 .iter_mut()

--- a/src/model/containers.rs
+++ b/src/model/containers.rs
@@ -52,30 +52,21 @@ where
     /// Returns `true` if the option is an `Any` value.
     ///
     pub fn is_any(&self) -> bool {
-        match self {
-            OneOrAny::Any => true,
-            _ => false,
-        }
+        matches!(self, OneOrAny::Any)
     }
 
     ///
     /// Returns `true` if the option is an `One` value.
     ///
     pub fn is_one(&self) -> bool {
-        match self {
-            OneOrAny::One(_) => true,
-            _ => false,
-        }
+        matches!(self, OneOrAny::One(_))
     }
 
     ///
     /// Returns `true` if the option is an `AnyOf` value.
     ///
     pub fn is_any_of(&self) -> bool {
-        match self {
-            OneOrAny::AnyOf(_) => true,
-            _ => false,
-        }
+        matches!(self, OneOrAny::AnyOf(_))
     }
 
     ///
@@ -99,7 +90,7 @@ where
     ///
     pub fn any_of(self) -> Option<Vec<T>> {
         match self {
-            OneOrAny::AnyOf(values) => Some(values.clone()),
+            OneOrAny::AnyOf(values) => Some(values),
             _ => None,
         }
     }

--- a/src/model/impls.rs
+++ b/src/model/impls.rs
@@ -430,7 +430,7 @@ fn random_id(prefix: &str) -> String {
         "{}{}",
         prefix,
         Uuid::new_v4()
-            .to_hyphenated()
+            .as_hyphenated()
             .encode_lower(&mut Uuid::encode_buffer())
     )
 }

--- a/src/model/impls.rs
+++ b/src/model/impls.rs
@@ -410,7 +410,7 @@ impl<'de> Visitor<'de> for ConditionOperatorVisitor {
     where
         E: de::Error,
     {
-        ConditionOperator::from_str(&value).map_err(de::Error::custom)
+        ConditionOperator::from_str(value).map_err(de::Error::custom)
     }
 
     fn visit_string<E>(self, value: String) -> Result<Self::Value, E>

--- a/src/model/qstring.rs
+++ b/src/model/qstring.rs
@@ -157,7 +157,7 @@ impl<'de> Visitor<'de> for QStringVisitor {
     where
         E: de::Error,
     {
-        QString::from_str(&value).map_err(de::Error::custom)
+        QString::from_str(value).map_err(de::Error::custom)
     }
 
     fn visit_string<E>(self, value: String) -> Result<Self::Value, E>

--- a/src/model/qstring.rs
+++ b/src/model/qstring.rs
@@ -3,11 +3,9 @@ Provides a namespace-qualified string.
 */
 
 use regex::Regex;
-use serde::export::fmt::Error;
-use serde::export::Formatter;
 use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt;
 use std::fmt::Display;
+use std::fmt::{self, Error, Formatter};
 use std::str::FromStr;
 use std::string::ToString;
 

--- a/src/offline/operators.rs
+++ b/src/offline/operators.rs
@@ -1,10 +1,8 @@
 use crate::model::{ConditionValue, GlobalConditionOperator, QString};
 use crate::offline::variables::expand_string;
 use crate::offline::EvaluationError;
-use serde::export::fmt::Error;
-use serde::export::Formatter;
 use std::collections::HashMap;
-use std::fmt::Display;
+use std::fmt::{Display, Error, Formatter};
 use std::string::ToString;
 use tracing::{error, instrument};
 

--- a/src/offline/request.rs
+++ b/src/offline/request.rs
@@ -73,7 +73,7 @@ impl Request {
     pub fn request_id() -> Option<String> {
         Some(
             Uuid::new_v4()
-                .to_hyphenated()
+                .as_hyphenated()
                 .encode_lower(&mut Uuid::encode_buffer())
                 .to_string(),
         )

--- a/src/offline/statement.rs
+++ b/src/offline/statement.rs
@@ -299,8 +299,7 @@ fn eval_statement_conditions(
     let result = if let Some(conditions) = statement_conditions {
         let results = conditions
             .iter()
-            .map(|(op, vs)| eval_statement_condition_op(request_environment, op, vs))
-            .flatten()
+            .flat_map(|(op, vs)| eval_statement_condition_op(request_environment, op, vs))
             .collect();
         match results {
             Ok(mut results) => Ok(reduce_optional_results(&mut results)),
@@ -371,12 +370,12 @@ fn string_match(lhs: &str, rhs: &str) -> bool {
 }
 
 #[inline]
-fn contains_match(lhs: &str, rhs: &Vec<String>) -> bool {
+fn contains_match(lhs: &str, rhs: &[String]) -> bool {
     rhs.iter().any(|r| string_match(lhs, r))
 }
 
 #[inline]
-fn contains_qmatch(lhs: &str, rhs: &Vec<QString>) -> bool {
+fn contains_qmatch(lhs: &str, rhs: &[QString]) -> bool {
     rhs.iter().any(|r| string_match(lhs, &r.to_string()))
 }
 
@@ -410,7 +409,7 @@ fn resource_split(lhs: &str) -> Vec<String> {
 }
 
 #[inline]
-fn contains_resource(lhs: &str, rhs: &Vec<String>) -> bool {
+fn contains_resource(lhs: &str, rhs: &[String]) -> bool {
     rhs.iter().any(|r| resource_match(lhs, r))
 }
 

--- a/src/offline/variables.rs
+++ b/src/offline/variables.rs
@@ -32,7 +32,7 @@ pub fn expand_string(
         let key = QString::from_str(key)
             .map_err(|_| EvaluationError::InvalidVariableName(key.to_string()))?;
         match environment.get(&key) {
-            Some(ConditionValue::String(v)) => output.push_str(&v),
+            Some(ConditionValue::String(v)) => output.push_str(v),
             None => return Err(EvaluationError::UnknownVariableName(key.to_string())),
             _ => return Err(EvaluationError::ExpectingVariableType("String".to_string())),
         };


### PR DESCRIPTION
This PR also addresses several `clippy` lints and upgrades the `uuid` dependency.

```
⇒ cargo test --all-features
    Finished test [optimized + debuginfo] target(s) in 0.09s
     Running unittests src\lib.rs (target\debug\deps\aws_iam-a55055e5c3b6cd48.exe)

running 20 tests
test model::impls::test::test_condition_type_bad ... ok{
  "Id": "confidential-data-access",
  "Statement": {
    "Sid": "sid_5986778a-4fdf-4d4e-b466-387e77e363fd",
    "Effect": "Allow",
    "Action": [
      "s3:List*",
      "s3:Get*"
    ],
    "Resource": [
      "arn:aws:s3:::confidential-data",
      "arn:aws:s3:::confidential-data/*"
    ],
    "Condition": {
      "BoolIfExists": {
        "aws:MultiFactorAuthPresent": true
      }
    }
  }
}
test model::impls::test::test_condition_type_parts_ok ... ok
test model::impls::test::test_condition_type_ok ... ok

<SNIP>
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.58s
```